### PR TITLE
New Functions and examples for them

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Adafruit Python MCP4725
-Python code to use the MCP4725 digital to analog converter with a Raspberry Pi or BeagleBone black.
+Python code to use the MCP4725 digital to analog converter with a Raspberry Pi, BeagleBone black, or Odroid C.
 
 ## Installation
 

--- a/examples/powerdown_demo.py
+++ b/examples/powerdown_demo.py
@@ -1,0 +1,22 @@
+# A demo to show off power-down mode
+# Author: Blake Felt
+
+import time
+import Adafruit_MCP4725
+
+dac = Adafruit_MCP4725.MCP4725()
+
+voltage = 4095 # voltage to write for demo
+sleep_time = 2 # time to pause between commands
+
+modes = [1,100,500] # all available shutdown modes (see datasheet)
+
+for i in modes: # for every mode
+    dac.set_voltage(voltage) # turn on device
+    print 'turned on device'
+    time.sleep(sleep_time) 
+    resistor = dac.power_down(i) # enter power-down mode with the set resistor
+    print 'Entered power-down mode with {0}kOhm resistor'.format(resistor)
+    time.sleep(sleep_time)
+
+dac.power_down() # defaults to 1 kOhm resistor

--- a/examples/speed_comparison.py
+++ b/examples/speed_comparison.py
@@ -1,0 +1,27 @@
+# A speed comparison of the set_voltage and set_fast commands
+# Sets voltage from 0 to Vdd, then prints time taken
+# Author: Blake Felt
+
+import time
+import Adafruit_MCP4725
+
+# create dac instance
+dac = Adafruit_MCP4725.MCP4725()
+
+max_volts = 4095
+
+print 'Press ctrl+C to quit:'
+while True:
+    tic1 = time.time() # find current time
+    for i in xrange(max_volts+1): # for every voltage value
+        dac.set_voltage(i) # set voltage
+    toc1 = time.time()-tic1 # find time elapsed
+
+    tic2 = time.time()
+    for i in xrange(max_volts+1):
+        dac.set_fast(i)
+    toc2 = time.time()-tic2
+    
+    # print times
+    print 'It took {0} seconds to write every voltage with set_voltage'.format(toc1)
+    print 'It took {0} seconds to write every voltage with set_fast\n'.format(toc2)


### PR DESCRIPTION
I added two new functions, _set_fast_ and _power_down_, along with two examples to show them off. I also added that this code works with the Odroid C-series in the README. 

_set_fast_ uses the fast-mode of MCP4725 to write the voltage faster. The only input is 'value', which is the voltage you wish to write. This is identical to the 'value' of set_voltage. It cannot write to the EEPROM, so this is not an optional input. 
The example for it shows off the speed difference between using set_fast and set_voltage

_power_down_ makes the MCP4725 enter power-down mode. Available options are 1, 100, and 500, which corresponds to the resistor that is put to ground (see datasheet, 100 corresponds to 100kOhm). It defaults to 1. 
The example for this applies a voltage, then enters power-down mode. This is repeated for all three power-down modes. 

These were all tested using an Odroid C1+ and python 2. I have never tried python 3, so the code may not work with that. Everything else is just bit-math, so it will work on the other boards. 
