### PR TITLE
Fix for i2c address in example.

### DIFF
--- a/examples/simpletest.py
+++ b/examples/simpletest.py
@@ -12,7 +12,7 @@ dac = Adafruit_MCP4725.MCP4725()
 
 # Note you can change the I2C address from its default (0x62), and/or the I2C
 # bus by passing in these optional parameters:
-#dac = Adafruit_MCP4725.MCP4725(address=0x49, busnum=1)
+#dac = Adafruit_MCP4725.MCP4725(address=0x62, busnum=1)
 
 # Loop forever alternating through different voltage outputs.
 print('Press Ctrl-C to quit...')


### PR DESCRIPTION
This PR is to change the i2c address in the MCP4725 example code, simpletest.py from 0x49 to 0x62. The address used in the comment, 0x49, is not a valid address for the MCP4725, so it could introduce a source of confusion to anyone following the example.
